### PR TITLE
Add python and jupyter as built-in extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -619,6 +619,14 @@
 				"publisherDisplayName": "Microsoft",
 				"publisherId": "998b010b-e2af-44a5-a6cd-0b5fd3b9b6f8"
 			}
+		},
+		{
+			"name": "ms-toolsai.jupyter",
+			"version": "2021.8.1054968649",
+			"repo": "https://github.com/microsoft/vscode-jupyter",
+			"metadata": {
+				"publisherDisplayName": "Microsoft"
+			}
 		}
 	],
 	"extensionsGallery": {

--- a/product.json
+++ b/product.json
@@ -28,6 +28,7 @@
 		"GitHub.vscode-pull-request-github",
 		"GitHub.vscode-pull-request-github-insiders",
 		"ms-python.python",
+		"ms-toolsai.jupyter",
 		"ms-vscode.js-debug-nightly",
 		"ms-vscode.js-debug",
 		"ms-vscode.lsif-browser",
@@ -607,6 +608,16 @@
 					"flags": "verified"
 				},
 				"publisherDisplayName": "Red Hat"
+			}
+		},
+		{
+			"name": "ms-python.python",
+			"version": "2021.8.1159798656",
+			"repo": "https://github.com/microsoft/vscode-python",
+			"metadata": {
+				"id": "f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5",
+				"publisherDisplayName": "Microsoft",
+				"publisherId": "998b010b-e2af-44a5-a6cd-0b5fd3b9b6f8"
 			}
 		}
 	],


### PR DESCRIPTION
This is a provisional python/jupter addition. Long term we want to install from a local package, not marketplace.