### PR TITLE
Customize default vscode settings

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -712,7 +712,15 @@ async function doStart(): Promise<IDisposable> {
 			}
 		},
 		configurationDefaults: {
+			'workbench.preferredDarkColorTheme': 'Leap IDE Dark',
+			'workbench.preferredLightColorTheme': 'Leap IDE Light',
 			'workbench.colorTheme': 'Leap IDE Dark',
+			'workbench.tree.indent': 16,		// double the default value
+			'workbench.tree.renderIndentGuides': 'always',
+			'editor.minimap.enabled': false,
+			'terminal.integrated.copyOnSelection': true,
+			'extensions.autoCheckUpdates': false,
+			'extensions.autoUpdate': false,
 		},
 		developmentOptions: {
 			logLevel: logLevel ? parseLogLevel(logLevel) : undefined


### PR DESCRIPTION
Changes:
- Leap IDE is the new preferred theme
- nicer tree in the files explorer
- copy-on-select in terminal
- don't auto-update extensions
