### PR TITLE
Add basic kiosk mode support to Simple Browser built-in extension

### DIFF
--- a/extensions/gitpod/package.json
+++ b/extensions/gitpod/package.json
@@ -18,7 +18,8 @@
     "*",
     "onAuthenticationRequest:gitpod",
     "onAuthenticationRequest:github",
-    "onCommand:gitpod.api.preview"
+    "onCommand:gitpod.api.preview",
+    "onCommand:gitpod.api.openProblemInspector"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/extensions/gitpod/src/extension.ts
+++ b/extensions/gitpod/src/extension.ts
@@ -567,6 +567,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('gitpod.api.preview', (url: string) =>
 		previewUrl(url)
 	));
+	context.subscriptions.push(vscode.commands.registerCommand('gitpod.api.openProblemInspector', (url: string) =>
+		openProblemInspector(url)
+	));
 	context.subscriptions.push(vscode.commands.registerCommand('gitpod.ports.openBrowser', (port: GitpodWorkspacePort) =>
 		port.openExternal()
 	));
@@ -645,6 +648,14 @@ export async function activate(context: vscode.ExtensionContext) {
 		await vscode.commands.executeCommand('simpleBrowser.api.open', url, {
 			viewColumn: vscode.ViewColumn.Beside,
 			preserveFocus: true
+		});
+	}
+	async function openProblemInspector(url: string): Promise<void> {
+		await vscode.commands.executeCommand('simpleBrowser.api.open', url, {
+			viewColumn: vscode.ViewColumn.Beside,
+			preserveFocus: true,
+			kioskMode: true,
+			title: "Problem Inspector"
 		});
 	}
 	context.subscriptions.push(gitpodWorkspaceTreeDataProvider.onDidExposeServedPort(port => {

--- a/extensions/simple-browser/media/main.css
+++ b/extensions/simple-browser/media/main.css
@@ -70,6 +70,15 @@ button:focus {
 	margin: 0.4em 1em;
 }
 
+.header.kiosk {
+	margin: 0;
+}
+
+.header.kiosk .controls,
+.header.kiosk .url-input {
+	display: none;
+}
+
 .url-input {
 	flex: 1;
 }

--- a/extensions/simple-browser/src/extension.ts
+++ b/extensions/simple-browser/src/extension.ts
@@ -51,6 +51,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand(openApiCommand, (url: vscode.Uri, showOptions?: {
 		preserveFocus?: boolean,
 		viewColumn: vscode.ViewColumn,
+		kioskMode?: boolean,
+		title?: string
 	}) => {
 		manager.show(url.toString(), showOptions);
 	}));


### PR DESCRIPTION
We add `kioskMode` and `title` options to `simpleBrowser.api.open`
command API call.
