### PR TITLE
Open external links from simple-browser in a new window

### DIFF
--- a/extensions/simple-browser/preview-src/index.ts
+++ b/extensions/simple-browser/preview-src/index.ts
@@ -41,6 +41,13 @@ window.addEventListener('message', e => {
 				toggleFocusLockIndicatorEnabled(e.data.enabled);
 				break;
 			}
+		case 'openExternal':
+			{
+				if (settings.kioskMode) {
+					vscode.postMessage({type: e.data.type, url: e.data.url});
+				}
+				break;
+			}
 	}
 });
 

--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -111,7 +111,8 @@ export class SimpleBrowserView extends Disposable {
 
 				<meta id="simple-browser-settings" data-settings="${escapeAttribute(JSON.stringify({
 			url: url,
-			focusLockEnabled: configuration.get<boolean>('focusLockIndicator.enabled', true)
+			focusLockEnabled: configuration.get<boolean>('focusLockIndicator.enabled', true),
+			kioskMode: kioskMode
 		}))}">
 
 				<link rel="stylesheet" type="text/css" href="${mainCss}">


### PR DESCRIPTION
Implement `openExternal` command on `postMessage` from webview content rendered in kiosk mode.

This enables opening of external links in new browser tabs.