### PR TITLE
Fix terminal rendering on iOS/osx (temporary fix)

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -239,7 +239,7 @@ const terminalConfiguration: IConfigurationNode = {
 				localize('terminal.integrated.gpuAcceleration.off', "Disable GPU acceleration within the terminal."),
 				localize('terminal.integrated.gpuAcceleration.canvas', "Use the fallback canvas renderer within the terminal. This uses a 2d context instead of webgl and may be better on some systems.")
 			],
-			default: 'auto',
+			default: 'off',
 			description: localize('terminal.integrated.gpuAcceleration', "Controls whether the terminal will leverage the GPU to do its rendering.")
 		},
 		[TerminalSettingId.RightClickBehavior]: {


### PR DESCRIPTION
Apply a fix from https://github.com/gitpod-io/gitpod/issues/5040 until we upgrade to vscode 1.61+.
