### PR TITLE
Backport clickable links in markdown jupyter cells

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 const MarkdownIt = require('markdown-it');
+import type * as markdownIt from 'markdown-it';
 
 export function activate() {
 	let markdownIt = new MarkdownIt({
 		html: true
 	});
+	addNamedHeaderRendering(markdownIt);
 
 	const style = document.createElement('style');
 	style.textContent = `
@@ -180,4 +182,50 @@ export function activate() {
 			f(markdownIt);
 		}
 	};
+}
+
+
+function addNamedHeaderRendering(md: markdownIt.MarkdownIt): void {
+	const slugCounter = new Map<string, number>();
+
+	const originalHeaderOpen = md.renderer.rules.heading_open;
+	md.renderer.rules.heading_open = (tokens: markdownIt.Token[], idx: number, options: any, env: any, self: any) => {
+		const title = tokens[idx + 1].children.reduce((acc: string, t: any) => acc + t.content, '');
+		let slug = slugFromHeading(title);
+
+		if (slugCounter.has(slug)) {
+			const count = slugCounter.get(slug)!;
+			slugCounter.set(slug, count + 1);
+			slug = slugFromHeading(slug + '-' + (count + 1));
+		} else {
+			slugCounter.set(slug, 0);
+		}
+
+		tokens[idx].attrs = tokens[idx].attrs || [];
+		tokens[idx].attrs.push(['id', slug]);
+
+		if (originalHeaderOpen) {
+			return originalHeaderOpen(tokens, idx, options, env, self);
+		} else {
+			return self.renderToken(tokens, idx, options, env, self);
+		}
+	};
+
+	const originalRender = md.render;
+	md.render = function () {
+		slugCounter.clear();
+		return originalRender.apply(this, arguments as any);
+	};
+}
+
+function slugFromHeading(heading: string): string {
+	const slugifiedHeading = encodeURI(
+		heading.trim()
+			.toLowerCase()
+			.replace(/\s+/g, '-') // Replace whitespace with -
+			.replace(/[\]\[\!\'\#\$\%\&\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`。，、；：？！…—·ˉ¨‘’“”々～‖∶＂＇｀｜〃〔〕〈〉《》「」『』．〖〗【】（）［］｛｝]/g, '') // Remove known punctuators
+			.replace(/^\-+/, '') // Remove leading -
+			.replace(/\-+$/, '') // Remove trailing -
+	);
+	return slugifiedHeading;
 }

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1392,7 +1392,7 @@ const _ttpSafeInnerHtml = window.trustedTypes?.createPolicy('safeInnerHtml', {
 export function safeInnerHtml(node: HTMLElement, value: string): void {
 
 	const options = _extInsaneOptions({
-		allowedTags: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
+		allowedTags: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
 		allowedAttributes: {
 			'a': ['href', 'x-dispatch'],
 			'button': ['data-href', 'x-dispatch'],

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
@@ -651,6 +651,10 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		return new Promise<void>(resolve => { r = resolve; });
 	}
 
+	setScrollTop(scrollTop: number): void {
+		this._list.scrollTop = scrollTop;
+	}
+
 	triggerScroll(event: IMouseWheelEvent) {
 		this._list.triggerScrollFromMouseWheelEvent(event);
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -30,7 +30,7 @@ import { NotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookEd
 import { isCompositeNotebookEditorInput, NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { NotebookService } from 'vs/workbench/contrib/notebook/browser/notebookServiceImpl';
-import { CellKind, CellToolbarLocation, CellToolbarVisibility, CellUri, DisplayOrderKey, UndoRedoPerCell, ExperimentalUseMarkdownRenderer, IResolvedNotebookEditorModel, NotebookDocumentBackupData, NotebookTextDiffEditorPreview, NotebookWorkingCopyTypeIdentifier, ShowCellStatusBar, CompactView, FocusIndicator, InsertToolbarLocation, GlobalToolbar, ConsolidatedOutputButton, ShowFoldingControls, DragAndDropEnabled, NotebookCellEditorOptionsCustomizations, ConsolidatedRunButton } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, CellToolbarLocation, CellToolbarVisibility, CellUri, DisplayOrderKey, UndoRedoPerCell, IResolvedNotebookEditorModel, NotebookDocumentBackupData, NotebookTextDiffEditorPreview, NotebookWorkingCopyTypeIdentifier, ShowCellStatusBar, CompactView, FocusIndicator, InsertToolbarLocation, GlobalToolbar, ConsolidatedOutputButton, ShowFoldingControls, DragAndDropEnabled, NotebookCellEditorOptionsCustomizations, ConsolidatedRunButton } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
@@ -648,11 +648,6 @@ configurationRegistry.registerConfiguration({
 		},
 		[NotebookTextDiffEditorPreview]: {
 			description: nls.localize('notebook.diff.enablePreview.description', "Whether to use the enhanced text diff editor for notebook."),
-			type: 'boolean',
-			default: true
-		},
-		[ExperimentalUseMarkdownRenderer]: {
-			description: nls.localize('notebook.experimental.useMarkdownRenderer.description', "Enable/disable using the new extensible markdown renderer."),
 			type: 'boolean',
 			default: true
 		},

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -749,7 +749,6 @@ export interface MarkdownCellRenderTemplate extends BaseCellRenderTemplate {
 	foldingIndicator: HTMLElement;
 	focusIndicatorBottom: HTMLElement;
 	currentEditor?: ICodeEditor;
-	readonly useRenderer: boolean;
 }
 
 export interface CodeCellRenderTemplate extends BaseCellRenderTemplate {

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -177,6 +177,7 @@ export interface IFocusNotebookCellOptions {
 export interface ICommonNotebookEditor {
 	readonly creationOptions: INotebookEditorCreationOptions;
 	getCellOutputLayoutInfo(cell: IGenericCellViewModel): INotebookCellOutputLayoutInfo;
+	setScrollTop(scrollTop: number): void;
 	triggerScroll(event: IMouseWheelEvent): void;
 	getCellByInfo(cellInfo: ICommonCellInfo): IGenericCellViewModel;
 	getCellById(cellId: string): IGenericCellViewModel | undefined;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -82,6 +82,10 @@ export class ListViewInfoAccessor extends Disposable {
 		super();
 	}
 
+	setScrollTop(scrollTop: number) {
+		this.list.scrollTop = scrollTop;
+	}
+
 	revealCellRangeInView(range: ICellRange) {
 		return this.list.revealElementsInView(range);
 	}
@@ -1776,6 +1780,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 
 	getVisibleRangesPlusViewportAboveBelow(): ICellRange[] {
 		return this._listViewInfoAccessor.getVisibleRangesPlusViewportAboveBelow();
+	}
+
+	setScrollTop(scrollTop: number) {
+		this._listViewInfoAccessor.setScrollTop(scrollTop);
 	}
 
 	triggerScroll(event: IMouseWheelEvent) {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -33,16 +33,12 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
-import { StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { contrastBorder, diffInserted, diffRemoved, editorBackground, errorForeground, focusBorder, foreground, listInactiveSelectionBackground, registerColor, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, textBlockQuoteBackground, textBlockQuoteBorder, textLinkActiveForeground, textLinkForeground, textPreformatForeground, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
-import { EditorMemento } from 'vs/workbench/browser/parts/editor/editorPane';
-import { IEditorMemento } from 'vs/workbench/common/editor';
-import { Memento, MementoObject } from 'vs/workbench/common/memento';
 import { PANEL_BORDER } from 'vs/workbench/common/theme';
 import { debugIconStartForeground } from 'vs/workbench/contrib/debug/browser/debugColors';
-import { CellEditState, CellFocusMode, IActiveNotebookEditor, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookCellList, INotebookCellOutputLayoutInfo, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorContributionDescription, INotebookEditorCreationOptions, INotebookEditorMouseEvent, INotebookEditorOptions, NotebookLayoutInfo, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_EDITOR_ID, NOTEBOOK_OUTPUT_FOCUSED, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellEditState, CellFocusMode, IActiveNotebookEditor, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookCellList, INotebookCellOutputLayoutInfo, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorContributionDescription, INotebookEditorCreationOptions, INotebookEditorMouseEvent, INotebookEditorOptions, NotebookLayoutInfo, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookDecorationCSSRules, NotebookRefCountedStyleSheet } from 'vs/workbench/contrib/notebook/browser/notebookEditorDecorations';
 import { NotebookEditorExtensionsRegistry } from 'vs/workbench/contrib/notebook/browser/notebookEditorExtensions';
 import { NotebookEditorKernelManager } from 'vs/workbench/contrib/notebook/browser/notebookEditorKernelManager';
@@ -62,7 +58,6 @@ import { CellKind, SelectionStateType } from 'vs/workbench/contrib/notebook/comm
 import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { editorGutterModifiedBackground } from 'vs/workbench/contrib/scm/browser/dirtydiffDecorator';
 import { Webview } from 'vs/workbench/contrib/webview/browser/webview';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { mark } from 'vs/workbench/contrib/notebook/common/notebookPerformance';
 import { readFontInfo } from 'vs/editor/browser/config/configuration';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
@@ -212,7 +207,6 @@ export function getDefaultNotebookCreationOptions() {
 }
 
 export class NotebookEditorWidget extends Disposable implements INotebookEditor {
-	private static readonly EDITOR_MEMENTOS = new Map<string, EditorMemento<unknown>>();
 	private _overlayContainer!: HTMLElement;
 	private _notebookTopToolbarContainer!: HTMLElement;
 	private _notebookTopToolbar!: NotebookEditorToolbar;
@@ -243,7 +237,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 	private _outputRenderer: OutputRenderer;
 	protected readonly _contributions = new Map<string, INotebookEditorContribution>();
 	private _scrollBeyondLastLine: boolean;
-	private readonly _memento: Memento;
 	private readonly _onDidFocusEmitter = this._register(new Emitter<void>());
 	public readonly onDidFocus = this._onDidFocusEmitter.event;
 	private readonly _onDidBlurEmitter = this._register(new Emitter<void>());
@@ -361,8 +354,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 				this._loadKernelPreloads();
 			}
 		}));
-
-		this._memento = new Memento(NOTEBOOK_EDITOR_ID, storageService);
 
 		this._outputRenderer = this._register(new OutputRenderer(this, this.instantiationService));
 		this._scrollBeyondLastLine = this.configurationService.getValue<boolean>('editor.scrollBeyondLastLine');
@@ -524,23 +515,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 	}
 
 	//#region Editor Core
-
-	protected getEditorMemento<T>(editorGroupService: IEditorGroupsService, key: string, limit: number = 10): IEditorMemento<T> {
-		const mementoKey = `${NOTEBOOK_EDITOR_ID}${key}`;
-
-		let editorMemento = NotebookEditorWidget.EDITOR_MEMENTOS.get(mementoKey);
-		if (!editorMemento) {
-			editorMemento = new EditorMemento(NOTEBOOK_EDITOR_ID, key, this.getMemento(StorageScope.WORKSPACE), limit, editorGroupService);
-			NotebookEditorWidget.EDITOR_MEMENTOS.set(mementoKey, editorMemento);
-		}
-
-		return editorMemento as IEditorMemento<T>;
-	}
-
-	protected getMemento(scope: StorageScope): MementoObject {
-		return this._memento.getMemento(scope, StorageTarget.MACHINE);
-	}
-
 	private _updateForNotebookConfiguration() {
 		if (!this._overlayContainer) {
 			return;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -520,6 +520,11 @@ var requirejs = (function() {
 						// console.log('ack top ', top, ' version: ', data.version, ' - ', date.getMinutes() + ':' + date.getSeconds() + ':' + date.getMilliseconds());
 						break;
 					}
+				case 'scroll-to-reveal':
+					{
+						this.notebookEditor.setScrollTop(data.scrollTop);
+						break;
+					}
 				case 'did-scroll-wheel':
 					{
 						this.notebookEditor.triggerScroll({

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -644,7 +644,14 @@ var requirejs = (function() {
 						this.notebookEditor.didEndDragMarkupCell(data.cellId);
 						break;
 					}
-
+				case 'renderedMarkup':
+					{
+						const cell = this.notebookEditor.getCellById(data.cellId);
+						if (cell instanceof MarkupCellViewModel) {
+							cell.renderedHtml = data.html;
+						}
+						break;
+					}
 				case 'telemetryFoundRenderedMarkdownMath':
 					{
 						this.telemetryService.publicLog2<{}, {}>('notebook/markdown/renderedLatex', {});

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
@@ -6,7 +6,7 @@
 import * as DOM from 'vs/base/browser/dom';
 import { disposableTimeout, raceCancellation } from 'vs/base/common/async';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
-import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -17,100 +17,22 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { getResizesObserver } from 'vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets';
 import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService';
 import { collapsedIcon, expandedIcon } from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { renderIcon } from 'vs/base/browser/ui/iconLabel/iconLabels';
 
-interface IMarkdownRenderStrategy extends IDisposable {
-	update(): void;
-}
-
-class WebviewMarkdownRenderer extends Disposable implements IMarkdownRenderStrategy {
-	constructor(
-		readonly notebookEditor: IActiveNotebookEditor,
-		readonly viewCell: MarkupCellViewModel
-	) {
-		super();
-	}
-
-	update(): void {
-		this.notebookEditor.createMarkupPreview(this.viewCell);
-	}
-}
-
-class BuiltinMarkdownRenderer extends Disposable implements IMarkdownRenderStrategy {
-	private readonly localDisposables = this._register(new DisposableStore());
-
-	constructor(
-		private readonly notebookEditor: IActiveNotebookEditor,
-		private readonly viewCell: MarkupCellViewModel,
-		private readonly container: HTMLElement,
-		private readonly markdownContainer: HTMLElement,
-		private readonly editorAccessor: () => CodeEditorWidget | null
-	) {
-		super();
-
-		this._register(getResizesObserver(this.markdownContainer, undefined, () => {
-			if (viewCell.getEditState() === CellEditState.Preview) {
-				this.viewCell.renderedMarkdownHeight = container.clientHeight;
-			}
-		})).startObserving();
-	}
-
-	update(): void {
-
-		const markdownRenderer = this.viewCell.getMarkdownRenderer();
-		const renderedHTML = this.viewCell.getHTML();
-		if (renderedHTML) {
-			this.markdownContainer.appendChild(renderedHTML);
-		}
-
-		if (this.editorAccessor()) {
-			// switch from editing mode
-			this.viewCell.renderedMarkdownHeight = this.container.clientHeight;
-			this.relayoutCell();
-		} else {
-			this.localDisposables.clear();
-			this.localDisposables.add(markdownRenderer.onDidRenderAsync(() => {
-				if (this.viewCell.getEditState() === CellEditState.Preview) {
-					this.viewCell.renderedMarkdownHeight = this.container.clientHeight;
-				}
-				this.relayoutCell();
-			}));
-
-			this.localDisposables.add(this.viewCell.textBuffer.onDidChangeContent(() => {
-				this.markdownContainer.innerText = '';
-				this.viewCell.clearHTML();
-				const renderedHTML = this.viewCell.getHTML();
-				if (renderedHTML) {
-					this.markdownContainer.appendChild(renderedHTML);
-				}
-			}));
-
-			this.viewCell.renderedMarkdownHeight = this.container.clientHeight;
-			this.relayoutCell();
-		}
-	}
-
-	relayoutCell() {
-		this.notebookEditor.layoutNotebookCell(this.viewCell, this.viewCell.layoutInfo.totalHeight);
-	}
-}
 
 export class StatefulMarkdownCell extends Disposable {
 
 	private editor: CodeEditorWidget | null = null;
 
-	private markdownContainer: HTMLElement;
+	private markdownAccessibilityContainer: HTMLElement;
 	private editorPart: HTMLElement;
 
 	private readonly localDisposables = this._register(new DisposableStore());
 	private readonly focusSwitchDisposable = this._register(new MutableDisposable());
 	private readonly editorDisposables = this._register(new DisposableStore());
 	private foldingState: CellFoldingState;
-	private useRenderer: boolean = false;
-	private renderStrategy: IMarkdownRenderStrategy;
 
 	constructor(
 		private readonly notebookEditor: IActiveNotebookEditor,
@@ -118,25 +40,28 @@ export class StatefulMarkdownCell extends Disposable {
 		private readonly templateData: MarkdownCellRenderTemplate,
 		private editorOptions: IEditorOptions,
 		private readonly renderedEditors: Map<ICellViewModel, ICodeEditor | undefined>,
-		options: { useRenderer: boolean; },
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@INotebookCellStatusBarService readonly notebookCellStatusBarService: INotebookCellStatusBarService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 
-		this.markdownContainer = templateData.cellContainer;
+		// Create an element that is only used to announce markup cell content to screen readers
+		const id = `aria-markup-cell-${this.viewCell.id}`;
+		this.markdownAccessibilityContainer = templateData.cellContainer;
+		this.markdownAccessibilityContainer.id = id;
+		// Hide the element from non-screen readers
+		this.markdownAccessibilityContainer.style.height = '1px';
+		this.markdownAccessibilityContainer.style.position = 'absolute';
+		this.markdownAccessibilityContainer.style.top = '10000px';
+		this.markdownAccessibilityContainer.ariaHidden = 'false';
+
+		this.templateData.rootContainer.setAttribute('aria-describedby', id);
+
 		this.editorPart = templateData.editorPart;
-		this.useRenderer = options.useRenderer;
 
-		if (this.useRenderer) {
-			this.templateData.container.classList.toggle('webview-backed-markdown-cell', true);
-			this.renderStrategy = new WebviewMarkdownRenderer(this.notebookEditor, this.viewCell);
-		} else {
-			this.renderStrategy = new BuiltinMarkdownRenderer(this.notebookEditor, this.viewCell, this.templateData.container, this.markdownContainer, () => this.editor);
-		}
+		this.templateData.container.classList.toggle('webview-backed-markdown-cell', true);
 
-		this._register(this.renderStrategy);
 		this._register(toDisposable(() => renderedEditors.delete(this.viewCell)));
 
 		this._register(viewCell.onDidChangeState((e) => {
@@ -199,11 +124,9 @@ export class StatefulMarkdownCell extends Disposable {
 			}
 		}));
 
-		if (this.useRenderer) {
-			// the markdown preview's height might already be updated after the renderer calls `element.getHeight()`
-			if (this.viewCell.layoutInfo.totalHeight > 0) {
-				this.relayoutCell();
-			}
+		// the markdown preview's height might already be updated after the renderer calls `element.getHeight()`
+		if (this.viewCell.layoutInfo.totalHeight > 0) {
+			this.relayoutCell();
 		}
 
 		// apply decorations
@@ -211,32 +134,20 @@ export class StatefulMarkdownCell extends Disposable {
 		this._register(viewCell.onCellDecorationsChanged((e) => {
 			e.added.forEach(options => {
 				if (options.className) {
-					if (this.useRenderer) {
-						this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [options.className], []);
-					} else {
-						templateData.rootContainer.classList.add(options.className);
-					}
+					this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [options.className], []);
 				}
 			});
 
 			e.removed.forEach(options => {
 				if (options.className) {
-					if (this.useRenderer) {
-						this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [], [options.className]);
-					} else {
-						templateData.rootContainer.classList.remove(options.className);
-					}
+					this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [], [options.className]);
 				}
 			});
 		}));
 
 		viewCell.getCellDecorations().forEach(options => {
 			if (options.className) {
-				if (this.useRenderer) {
-					this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [options.className], []);
-				} else {
-					templateData.rootContainer.classList.add(options.className);
-				}
+				this.notebookEditor.deltaCellOutputContainerClassNames(this.viewCell.id, [options.className], []);
 			}
 		});
 
@@ -267,7 +178,8 @@ export class StatefulMarkdownCell extends Disposable {
 	private viewUpdateCollapsed(): void {
 		DOM.show(this.templateData.collapsedPart);
 		DOM.hide(this.editorPart);
-		DOM.hide(this.markdownContainer);
+		this.markdownAccessibilityContainer.ariaHidden = 'true';
+
 		this.templateData.container.classList.toggle('collapsed', true);
 		this.viewCell.renderedMarkdownHeight = 0;
 		this.viewCell.layoutChange({});
@@ -278,12 +190,10 @@ export class StatefulMarkdownCell extends Disposable {
 		let editorHeight: number;
 
 		DOM.show(this.editorPart);
-		DOM.hide(this.markdownContainer);
+		this.markdownAccessibilityContainer.ariaHidden = 'true';
 		DOM.hide(this.templateData.collapsedPart);
 
-		if (this.useRenderer) {
-			this.notebookEditor.hideMarkupPreviews([this.viewCell]);
-		}
+		this.notebookEditor.hideMarkupPreviews([this.viewCell]);
 
 		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('markdown-cell-edit-mode', true);
@@ -371,16 +281,18 @@ export class StatefulMarkdownCell extends Disposable {
 		this.viewCell.detachTextEditor();
 		DOM.hide(this.editorPart);
 		DOM.hide(this.templateData.collapsedPart);
-		DOM.show(this.markdownContainer);
+		this.markdownAccessibilityContainer.ariaHidden = 'false';
 		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('markdown-cell-edit-mode', false);
 
 		this.renderedEditors.delete(this.viewCell);
 
-		this.markdownContainer.innerText = '';
-		this.viewCell.clearHTML();
+		this.markdownAccessibilityContainer.innerText = '';
+		if (this.viewCell.renderedHtml) {
+			DOM.safeInnerHtml(this.markdownAccessibilityContainer, this.viewCell.renderedHtml);
+		}
 
-		this.renderStrategy.update();
+		this.notebookEditor.createMarkupPreview(this.viewCell);
 	}
 
 	private focusEditorIfNeeded() {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
@@ -54,7 +54,6 @@ export class StatefulMarkdownCell extends Disposable {
 		this.markdownAccessibilityContainer.style.height = '1px';
 		this.markdownAccessibilityContainer.style.position = 'absolute';
 		this.markdownAccessibilityContainer.style.top = '10000px';
-		this.markdownAccessibilityContainer.ariaHidden = 'false';
 
 		this.templateData.rootContainer.setAttribute('aria-describedby', id);
 
@@ -178,7 +177,6 @@ export class StatefulMarkdownCell extends Disposable {
 	private viewUpdateCollapsed(): void {
 		DOM.show(this.templateData.collapsedPart);
 		DOM.hide(this.editorPart);
-		this.markdownAccessibilityContainer.ariaHidden = 'true';
 
 		this.templateData.container.classList.toggle('collapsed', true);
 		this.viewCell.renderedMarkdownHeight = 0;
@@ -190,7 +188,6 @@ export class StatefulMarkdownCell extends Disposable {
 		let editorHeight: number;
 
 		DOM.show(this.editorPart);
-		this.markdownAccessibilityContainer.ariaHidden = 'true';
 		DOM.hide(this.templateData.collapsedPart);
 
 		this.notebookEditor.hideMarkupPreviews([this.viewCell]);
@@ -281,7 +278,6 @@ export class StatefulMarkdownCell extends Disposable {
 		this.viewCell.detachTextEditor();
 		DOM.hide(this.editorPart);
 		DOM.hide(this.templateData.collapsedPart);
-		this.markdownAccessibilityContainer.ariaHidden = 'false';
 		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('markdown-cell-edit-mode', false);
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -129,6 +129,12 @@ export interface IInitializedMarkupMessage extends BaseToWebviewMessage {
 	readonly type: 'initializedMarkup';
 }
 
+export interface IRenderedMarkupMessage extends BaseToWebviewMessage {
+	readonly type: 'renderedMarkup';
+	readonly cellId: string;
+	readonly html: string;
+}
+
 export interface ITelemetryFoundRenderedMarkdownMath extends BaseToWebviewMessage {
 	readonly type: 'telemetryFoundRenderedMarkdownMath';
 }
@@ -342,6 +348,7 @@ export type FromWebviewMessage = WebviewIntialized |
 	ICellDropMessage |
 	ICellDragEndMessage |
 	IInitializedMarkupMessage |
+	IRenderedMarkupMessage |
 	ITelemetryFoundRenderedMarkdownMath |
 	ITelemetryFoundUnrenderedMarkdownMath;
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -46,6 +46,11 @@ export interface IOutputBlurMessage extends BaseToWebviewMessage {
 	readonly id: string;
 }
 
+export interface IScrollToRevealMessage extends BaseToWebviewMessage {
+	readonly type: 'scroll-to-reveal';
+	readonly scrollTop: number;
+}
+
 export interface IWheelMessage extends BaseToWebviewMessage {
 	readonly type: 'did-scroll-wheel';
 	readonly payload: any;
@@ -332,6 +337,7 @@ export type FromWebviewMessage = WebviewIntialized |
 	IMouseLeaveMessage |
 	IOutputFocusMessage |
 	IOutputBlurMessage |
+	IScrollToRevealMessage |
 	IWheelMessage |
 	IScrollAckMessage |
 	IBlurOutputMessage |

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1163,19 +1163,25 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 
 			await renderers.render(this, this.element);
 
-			if (!hasPostedRenderedMathTelemetry) {
-				const hasRenderedMath = this.element.querySelector('.katex');
-				if (hasRenderedMath) {
-					hasPostedRenderedMathTelemetry = true;
-					postNotebookMessage<webviewMessages.ITelemetryFoundRenderedMarkdownMath>('telemetryFoundRenderedMarkdownMath', {});
-				}
-			}
+			if (this.mime === 'text/markdown') {
+				const root = this.element.shadowRoot;
+				if (root) {
+					if (!hasPostedRenderedMathTelemetry) {
+						const hasRenderedMath = root.querySelector('.katex');
+						if (hasRenderedMath) {
+							hasPostedRenderedMathTelemetry = true;
+							postNotebookMessage<webviewMessages.ITelemetryFoundRenderedMarkdownMath>('telemetryFoundRenderedMarkdownMath', {});
+						}
+					}
 
-			const matches = this.element.innerText.match(unsupportedKatexTermsRegex);
-			if (matches) {
-				postNotebookMessage<webviewMessages.ITelemetryFoundUnrenderedMarkdownMath>('telemetryFoundUnrenderedMarkdownMath', {
-					latexDirective: matches[0],
-				});
+					const innerText = root.querySelector<HTMLElement>('#preview')?.innerText;
+					const matches = innerText?.match(unsupportedKatexTermsRegex);
+					if (matches) {
+						postNotebookMessage<webviewMessages.ITelemetryFoundUnrenderedMarkdownMath>('telemetryFoundUnrenderedMarkdownMath', {
+							latexDirective: matches[0],
+						});
+					}
+				}
 			}
 
 			dimensionUpdater.updateHeight(this.id, this.element.offsetHeight, {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1130,6 +1130,27 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 				}
 			}
 
+			const root = (this.element.shadowRoot ?? this.element);
+			const html = [];
+			for (const child of root.children) {
+				switch (child.tagName) {
+					case 'LINK':
+					case 'SCRIPT':
+					case 'STYLE':
+						// not worth sending over since it will be stripped before rendering
+						break;
+
+					default:
+						html.push(child.outerHTML);
+						break;
+				}
+			}
+
+			postNotebookMessage<webviewMessages.IRenderedMarkupMessage>('renderedMarkup', {
+				cellId: this.id,
+				html: html.join(''),
+			});
+
 			dimensionUpdater.updateHeight(this.id, this.element.offsetHeight, {
 				isOutput: false
 			});

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -158,48 +158,6 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 		};
 	};
 
-	const runRenderScript = async (url: string, rendererId: string): Promise<ScriptModule> => {
-		const text = await loadScriptSource(url);
-		// TODO: Support both the new module based renderers and the old style global renderers
-		const isModule = !text.includes('acquireNotebookRendererApi');
-		if (isModule) {
-			return __import(url);
-		} else {
-			return createBackCompatModule(rendererId, url, text);
-		}
-	};
-
-	const createBackCompatModule = (rendererId: string, scriptUrl: string, scriptText: string): ScriptModule => ({
-		activate: (): RendererApi => {
-			const onDidCreateOutput = createEmitter<IOutputItem>();
-			const onWillDestroyOutput = createEmitter<undefined | IDestroyCellInfo>();
-
-			const globals = {
-				scriptUrl,
-				acquireNotebookRendererApi: <T>(): GlobalNotebookRendererApi<T> => ({
-					onDidCreateOutput: onDidCreateOutput.event,
-					onWillDestroyOutput: onWillDestroyOutput.event,
-					setState: newState => vscode.setState({ ...vscode.getState(), [rendererId]: newState }),
-					getState: () => {
-						const state = vscode.getState();
-						return typeof state === 'object' && state ? state[rendererId] as T : undefined;
-					},
-				}),
-			};
-
-			invokeSourceWithGlobals(scriptText, globals);
-
-			return {
-				renderOutputItem(outputItem) {
-					onDidCreateOutput.fire({ ...outputItem, outputId: outputItem.id });
-				},
-				disposeOutputItem(id) {
-					onWillDestroyOutput.fire(id ? { outputId: id } : undefined);
-				}
-			};
-		}
-	});
-
 	const dimensionUpdater = new class {
 		private readonly pending = new Map<string, webviewMessages.DimensionUpdate>();
 
@@ -477,19 +435,7 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 		bytes(): Uint8Array;
 	}
 
-	interface IDestroyCellInfo {
-		outputId: string;
-	}
-
 	const onDidReceiveKernelMessage = createEmitter<unknown>();
-
-	/** @deprecated */
-	interface GlobalNotebookRendererApi<T> {
-		setState: (newState: T) => void;
-		getState(): T | undefined;
-		readonly onWillDestroyOutput: Event<undefined | IDestroyCellInfo>;
-		readonly onDidCreateOutput: Event<IOutputItem>;
-	}
 
 	const kernelPreloadGlobals = {
 		acquireVsCodeApi,
@@ -766,7 +712,7 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 
 		/** Inner function cached in the _loadPromise(). */
 		private async _load(): Promise<RendererApi | undefined> {
-			const module = await runRenderScript(this.data.entrypoint, this.data.id);
+			const module = await __import(this.data.entrypoint);
 			if (!module) {
 				return;
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -63,7 +63,30 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 					handleBlobUrlClick(node.href, node.download);
 				} else if (node.href.startsWith('data:')) {
 					handleDataUrl(node.href, node.download);
+				} else if (node.hash && node.getAttribute('href') === node.hash) {
+					// Scrolling to location within current doc
+					const targetId = node.hash.substr(1, node.hash.length - 1);
+
+					// Check outer document first
+					let scrollTarget: Element | null | undefined = event.view.document.getElementById(targetId);
+
+					if (!scrollTarget) {
+						// Fallback to checking preview shadow doms
+						for (const preview of event.view.document.querySelectorAll('.preview')) {
+							scrollTarget = preview.shadowRoot?.getElementById(targetId);
+							if (scrollTarget) {
+								break;
+							}
+						}
+					}
+
+					if (scrollTarget) {
+						const scrollTop = scrollTarget.getBoundingClientRect().top + event.view.scrollY;
+						postNotebookMessage<webviewMessages.IScrollToRevealMessage>('scroll-to-reveal', { scrollTop });
+						return;
+					}
 				}
+
 				event.preventDefault();
 				return;
 			}
@@ -1398,6 +1421,7 @@ async function webviewPreloads(style: PreloadStyles, options: PreloadOptions, re
 				cellId: cellId
 			});
 		}
+
 	}();
 }
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -838,7 +838,6 @@ export const CellToolbarVisibility = 'notebook.cellToolbarVisibility';
 export type ShowCellStatusBarType = 'hidden' | 'visible' | 'visibleAfterExecute';
 export const ShowCellStatusBar = 'notebook.showCellStatusBar';
 export const NotebookTextDiffEditorPreview = 'notebook.diff.enablePreview';
-export const ExperimentalUseMarkdownRenderer = 'notebook.experimental.useMarkdownRenderer';
 export const ExperimentalInsertToolbarAlignment = 'notebook.experimental.insertToolbarAlignment';
 export const CompactView = 'notebook.compactView';
 export const FocusIndicator = 'notebook.cellFocusIndicator';


### PR DESCRIPTION
Backport a fix for https://github.com/microsoft/vscode/issues/103519 to support intradoc links in jupyter markdown cells.