### PR TITLE
Skip the external opener popup in Safari, fallback to alternative

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -12,7 +12,6 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { isIOS, isMacintosh } from 'vs/base/common/platform';
 import Severity from 'vs/base/common/severity';
-import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { registerWindowDriver } from 'vs/platform/driver/browser/driver';
@@ -147,27 +146,7 @@ export class BrowserWindow extends Disposable {
 					if (isSafari) {
 						const opened = windowOpenNoOpenerWithSuccess(href);
 						if (!opened) {
-							const showResult = await this.dialogService.show(
-								Severity.Warning,
-								localize('unableToOpenExternal', "The browser interrupted the opening of a new tab or window. Press 'Open' to open it anyway."),
-								[
-									localize('open', "Open"),
-									localize('learnMore', "Learn More"),
-									localize('cancel', "Cancel")
-								],
-								{
-									cancelId: 2,
-									detail: href
-								}
-							);
-
-							if (showResult.choice === 0) {
-								windowOpenNoOpener(href);
-							}
-
-							if (showResult.choice === 1) {
-								await this.openerService.open(URI.parse('https://aka.ms/allow-vscode-popup'));
-							}
+							windowOpenNoOpener(href);
 						}
 					} else {
 						windowOpenNoOpener(href);

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -26,9 +26,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { BeforeShutdownEvent, ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { getWorkspaceIdentifier } from 'vs/workbench/services/workspaces/browser/workspaces';
-import { localize } from 'vs/nls';
-import Severity from 'vs/base/common/severity';
-import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { DomEmitter } from 'vs/base/browser/event';
 
 /**
@@ -106,7 +103,6 @@ export class BrowserHostService extends Disposable implements IHostService {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@ILogService private readonly logService: ILogService,
-		@IDialogService private readonly dialogService: IDialogService
 	) {
 		super();
 
@@ -389,10 +385,7 @@ export class BrowserHostService extends Disposable implements IHostService {
 
 		const opened = await this.workspaceProvider.open(workspace, options);
 		if (!opened) {
-			const showResult = await this.dialogService.show(Severity.Warning, localize('unableToOpenExternal', "The browser interrupted the opening of a new tab or window. Press 'Open' to open it anyway."), [localize('open', "Open"), localize('cancel', "Cancel")], { cancelId: 2 });
-			if (showResult.choice === 0) {
-				await this.workspaceProvider.open(workspace, options);
-			}
+			await this.workspaceProvider.open(workspace, options);
 		}
 	}
 


### PR DESCRIPTION
Immediately try the alternative to open the external window.