### PR TITLE
Add timeout to extension download requests

### DIFF
--- a/product.json
+++ b/product.json
@@ -509,7 +509,8 @@
 		"itemUrl": "https://open-vsx.org/vscode/item",
 		"resourceUrlTemplate": "",
 		"controlUrl": "",
-		"recommendationsUrl": ""
+		"recommendationsUrl": "",
+		"requestTimeout": 60000
 	},
 	"linkProtectionTrustedDomains": [
 		"https://open-vsx.org",

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -72,6 +72,7 @@ export interface IProductConfiguration {
 		readonly resourceUrlTemplate: string;
 		readonly controlUrl: string;
 		readonly recommendationsUrl: string;
+		readonly requestTimeout?: number;
 	};
 
 	readonly extensionTips?: { [id: string]: string; };

--- a/src/vs/gitpod/node/server.ts
+++ b/src/vs/gitpod/node/server.ts
@@ -304,7 +304,8 @@ async function downloadInitialExtension(url: string, requestService: IRequestSer
 	const context = await requestService.request({
 		type: 'GET', url, headers: {
 			'Content-Type': '*/*' // GCP requires that the content-type header match those used during the signing operation (*/* in our case)
-		}
+		},
+		timeout: 60000
 	}, CancellationToken.None);
 	if (context.res.statusCode !== 200) {
 		const message = await asText(context);


### PR DESCRIPTION
Make sure extension install from gallery (marketplace) fails in finite time, if marketplace unavailable:
- add vscode config option: `extensionsGallery.requestTimeout` (default: 60 seconds)
- initial extension download requests timeout after 60 s (hard-coded)
- all extension gallery requests that use `extensionGalleryService`, timeout after  `extensionsGallery.requestTimeout`.
